### PR TITLE
Knock glyphs out of feedback category icons

### DIFF
--- a/img/feedback/confusing_audio.svg
+++ b/img/feedback/confusing_audio.svg
@@ -1,20 +1,92 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="70px" height="70px" viewBox="0 0 70 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
-    <title>feedback_button_2</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Feedback-UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Tintable-Assets" transform="translate(-237.000000, -343.000000)">
-            <g id="Group-Copy" transform="translate(13.000000, 238.000000)">
-                <g id="feedback_button_2" transform="translate(224.000000, 105.000000)">
-                    <path d="M70,35 C70,54.3305 54.327,70 35,70 C15.673,70 0,54.3305 0,35 C0,15.6695 15.673,0 35,0 C54.327,0 70,15.6695 70,35 Z" id="Stroke-1-Copy-2" fill="#000000"></path>
-                    <g id="Group" transform="translate(17.000000, 16.000000)" fill="#FFFFFF" fill-rule="nonzero">
-                        <g transform="translate(2.000000, 3.000000)" id="Icon">
-                            <path d="M0,10.5267831 L0,21.4732157 L7.33333333,21.4732157 L16.5,30.5952125 L16.5,1.40478629 L7.33333333,10.5267831 L0,10.5267831 Z M24.75,16.0000176 C24.75,12.7708308 22.88,9.99770726 20.1666667,8.64765174 L20.1666667,23.3341031 C22.88,22.0022915 24.75,19.2292045 24.75,16.0000176 Z M20.1666667,0 L20.1666667,3.75826146 C25.465,5.32724491 29.3333333,10.2166352 29.3333333,16.0000176 C29.3333333,21.7833636 25.465,26.6727539 20.1666667,28.2417373 L20.1666667,32 C27.5183333,30.3397966 33,23.8084469 33,16.0000176 C33,8.1915519 27.5183333,1.6602022 20.1666667,0 Z"></path>
-                        </g>
-                    </g>
-                </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   sodipodi:docname="confusing_audio.svg"
+   id="svg23"
+   version="1.1"
+   viewBox="0 0 70 70"
+   height="70px"
+   width="70px">
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>feedback_button_2</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs27" />
+  <sodipodi:namedview
+     inkscape:current-layer="feedback_button_2"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="33.720293"
+     inkscape:cx="40.566728"
+     inkscape:zoom="7.8142857"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview25"
+     inkscape:window-height="658"
+     inkscape:window-width="1135"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+  <title
+     id="title10">feedback_button_2</title>
+  <desc
+     id="desc12">Created with Sketch.</desc>
+  <g
+     fill-rule="evenodd"
+     fill="none"
+     stroke-width="1"
+     stroke="none"
+     id="Feedback-UI">
+    <g
+       transform="translate(-237.000000, -343.000000)"
+       id="Tintable-Assets">
+      <g
+         transform="translate(13.000000, 238.000000)"
+         id="Group-Copy">
+        <g
+           transform="translate(224.000000, 105.000000)"
+           id="feedback_button_2">
+          <g
+             style="fill:#000000;fill-opacity:1"
+             fill-rule="nonzero"
+             fill="#FFFFFF"
+             transform="translate(17.000000, 16.000000)"
+             id="Group">
+            <g
+               style="fill:#000000;fill-opacity:1"
+               id="Icon"
+               transform="translate(2.000000, 3.000000)">
+              <path
+                 style="fill:#000000;fill-opacity:1"
+                 d="M 0,10.526783 V 21.473216 H 7.3333333 L 16.5,30.595212 V 1.4047863 L 7.3333333,10.526783 Z m 24.75,5.473235 c 0,-3.229187 -1.87,-6.0023107 -4.583333,-7.3523663 V 23.334103 C 22.88,22.002291 24.75,19.229205 24.75,16.000018 Z M 20.166667,0 v 3.7582615 c 5.298333,1.5689834 9.166666,6.4583735 9.166666,12.2417565 0,5.783346 -3.868333,10.672736 -9.166666,12.241719 V 32 C 27.518333,30.339797 33,23.808447 33,16.000018 33,8.1915519 27.518333,1.6602022 20.166667,0 Z M 51,16 C 51,35.3305 35.327,51 16,51 -3.327,51 -19,35.3305 -19,16 c 0,-19.3305 15.673,-35 35,-35 19.327,0 35,15.6695 35,35 z"
+                 id="path15" />
             </g>
+          </g>
         </g>
+      </g>
     </g>
+  </g>
 </svg>

--- a/img/feedback/illegal_route.svg
+++ b/img/feedback/illegal_route.svg
@@ -1,20 +1,90 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="70px" height="70px" viewBox="0 0 70 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
-    <title>feedback_button_4</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Feedback-UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Tintable-Assets" transform="translate(-154.000000, -526.000000)">
-            <g id="Group-Copy" transform="translate(13.000000, 238.000000)">
-                <g id="Group-8" transform="translate(0.000000, 120.000000)">
-                    <g id="feedback_button_4" transform="translate(141.000000, 168.000000)">
-                        <path d="M70,35 C70,54.3305 54.327,70 35,70 C15.673,70 0,54.3305 0,35 C0,15.6695 15.673,0 35,0 C54.327,0 70,15.6695 70,35 Z" id="Stroke-1-Copy-8" fill="#000000"></path>
-                        <g id="Icon" transform="translate(17.000000, 16.000000)" fill="#FFFFFF">
-                            <path d="M18.0003217,6.38378239e-14 C20.299647,6.38378239e-14 22.3326263,1.20745247 23.4404713,3.23193916 L35.2227444,24.7553612 C36.2919885,26.7074525 36.2559611,29.0176426 35.1275289,30.9361217 C33.99781,32.8546008 31.9995715,34 29.781308,34 L6.21804865,34 C3.99978517,34 2.00154666,32.8546008 0.87311448,30.9361217 C-0.256604393,29.0176426 -0.291345178,26.7074525 0.776612299,24.7553612 L12.5588853,3.23193916 C13.6667304,1.20745247 15.7009964,6.38378239e-14 18.0003217,6.38378239e-14 Z M18,23 C16.34338,23 15,24.3421265 15,25.9991925 C15,27.6562584 16.34338,29 18,29 C19.65662,29 21,27.6562584 21,25.9991925 C21,24.3421265 19.65662,23 18,23 Z M18.3406889,7 L17.6593111,7 C16.1899892,7 15,8.26385321 15,9.82055046 L15,9.82055046 L15,18.1794495 C15,19.7378593 16.1899892,21 17.6593111,21 L17.6593111,21 L18.3406889,21 C19.8100108,21 21,19.7378593 21,18.1794495 L21,18.1794495 L21,9.82055046 C21,8.26385321 19.8100108,7 18.3406889,7 L18.3406889,7 Z" id="Combined-Shape"></path>
-                        </g>
-                    </g>
-                </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   sodipodi:docname="illegal_route.svg"
+   id="svg870"
+   version="1.1"
+   viewBox="0 0 70 70"
+   height="70px"
+   width="70px">
+  <metadata
+     id="metadata876">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>feedback_button_4</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs874" />
+  <sodipodi:namedview
+     inkscape:current-layer="feedback_button_4"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="35"
+     inkscape:cx="35"
+     inkscape:zoom="3.8857143"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview872"
+     inkscape:window-height="480"
+     inkscape:window-width="731"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+  <title
+     id="title858">feedback_button_4</title>
+  <desc
+     id="desc860">Created with Sketch.</desc>
+  <g
+     fill-rule="evenodd"
+     fill="none"
+     stroke-width="1"
+     stroke="none"
+     id="Feedback-UI">
+    <g
+       transform="translate(-154.000000, -526.000000)"
+       id="Tintable-Assets">
+      <g
+         transform="translate(13.000000, 238.000000)"
+         id="Group-Copy">
+        <g
+           transform="translate(0.000000, 120.000000)"
+           id="Group-8">
+          <g
+             transform="translate(141.000000, 168.000000)"
+             id="feedback_button_4">
+            <g
+               style="fill:#000000"
+               fill="#FFFFFF"
+               transform="translate(17.000000, 16.000000)"
+               id="Icon">
+              <path
+                 style="fill:#000000"
+                 d="m 18.000322,0 c 2.299325,0 4.332304,1.2074525 5.440149,3.2319392 L 35.222744,24.755361 c 1.069245,1.952091 1.033217,4.262282 -0.09521,6.180761 C 33.99781,32.854601 31.999571,34 29.781308,34 H 6.2180486 C 3.9997852,34 2.0015467,32.854601 0.87311448,30.936122 -0.25660439,29.017643 -0.29134518,26.707452 0.7766123,24.755361 L 12.558885,3.2319392 C 13.66673,1.2074525 15.700996,0 18.000322,0 Z M 18,23 c -1.65662,0 -3,1.342126 -3,2.999192 C 15,27.656258 16.34338,29 18,29 19.65662,29 21,27.656258 21,25.999192 21,24.342126 19.65662,23 18,23 Z M 18.340689,7 H 17.659311 C 16.189989,7 15,8.2638532 15,9.8205505 v 0 8.3588985 C 15,19.737859 16.189989,21 17.659311,21 v 0 h 0.681378 C 19.810011,21 21,19.737859 21,18.179449 v 0 -8.3588985 C 21,8.2638532 19.810011,7 18.340689,7 Z M 53,19 C 53,38.3305 37.327,54 18,54 -1.327,54 -17,38.3305 -17,19 c 0,-19.3305 15.673,-35 35,-35 19.327,0 35,15.6695 35,35 z"
+                 id="Combined-Shape" />
             </g>
+          </g>
         </g>
+      </g>
     </g>
+  </g>
 </svg>

--- a/img/feedback/incorrect_visual.svg
+++ b/img/feedback/incorrect_visual.svg
@@ -1,16 +1,81 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="70px" height="70px" viewBox="0 0 70 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
-    <title>feedback_button_1</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Feedback-UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Tintable-Assets" transform="translate(-68.000000, -343.000000)">
-            <g id="Group-Copy" transform="translate(13.000000, 238.000000)">
-                <g id="feedback_button_1" transform="translate(55.000000, 105.000000)">
-                    <path d="M70,35 C70,54.3305 54.327,70 35,70 C15.673,70 0,54.3305 0,35 C0,15.6695 15.673,0 35,0 C54.327,0 70,15.6695 70,35 Z" id="Stroke-1-Copy-6" fill="#000000"></path>
-                    <path d="M51.5619574,29.5872538 L38.0507761,20.1977074 C37.3499079,19.7015118 36.3764799,20.1977074 36.3764799,21.0374229 L36.3764799,26.7245872 L29.5235464,26.7245872 C21.5024993,26.7245872 15,33.0987915 15,40.9997513 L15,49.96944 C15,50.5419733 15.4672455,51 16.0513023,51 L21.5024993,51 C22.0865562,51 22.5538016,50.5419733 22.5538016,49.96944 L22.5538016,40.9997513 C22.5538016,37.2210314 25.6687714,34.1675204 29.5235464,34.1675204 L36.3764799,34.1675204 L36.3764799,39.8546847 C36.3764799,40.6944002 37.3499079,41.1905958 38.0507761,40.6944002 L51.5619574,31.3048538 C52.1460142,30.884996 52.1460142,30.0071116 51.5619574,29.5872538 Z" id="Icon" fill="#FFFFFF" fill-rule="nonzero" transform="translate(33.500000, 35.500000) scale(-1, 1) translate(-33.500000, -35.500000) "></path>
-                </g>
-            </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   sodipodi:docname="incorrect_visual.svg"
+   id="svg889"
+   version="1.1"
+   viewBox="0 0 70 70"
+   height="70px"
+   width="70px">
+  <metadata
+     id="metadata895">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>feedback_button_1</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs893" />
+  <sodipodi:namedview
+     inkscape:current-layer="feedback_button_1"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="35"
+     inkscape:cx="35"
+     inkscape:zoom="3.8857143"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview891"
+     inkscape:window-height="480"
+     inkscape:window-width="731"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+  <title
+     id="title879">feedback_button_1</title>
+  <desc
+     id="desc881">Created with Sketch.</desc>
+  <g
+     fill-rule="evenodd"
+     fill="none"
+     stroke-width="1"
+     stroke="none"
+     id="Feedback-UI">
+    <g
+       transform="translate(-68.000000, -343.000000)"
+       id="Tintable-Assets">
+      <g
+         transform="translate(13.000000, 238.000000)"
+         id="Group-Copy">
+        <g
+           transform="translate(55.000000, 105.000000)"
+           id="feedback_button_1">
+          <path
+             style="fill:#000000"
+             d="M 51.561957,29.587254 38.050776,20.197707 c -0.700868,-0.496195 -1.674296,0 -1.674296,0.839716 v 5.687164 H 29.523546 C 21.502499,26.724587 15,33.098791 15,40.999751 V 49.96944 C 15,50.541973 15.467246,51 16.051302,51 h 5.451197 c 0.584057,0 1.051303,-0.458027 1.051303,-1.03056 v -8.969689 c 0,-3.77872 3.114969,-6.832231 6.969744,-6.832231 h 6.852934 v 5.687165 c 0,0.839715 0.973428,1.335911 1.674296,0.839715 l 13.511181,-9.389546 c 0.584057,-0.419858 0.584057,-1.297742 0,-1.7176 z M -3,35 C -3,54.3305 12.673,70 32,70 51.327,70 67,54.3305 67,35 67,15.6695 51.327,0 32,0 12.673,0 -3,15.6695 -3,35 Z"
+             transform="translate(33.500000, 35.500000) scale(-1, 1) translate(-33.500000, -35.500000) "
+             id="Icon" />
         </g>
+      </g>
     </g>
+  </g>
 </svg>

--- a/img/feedback/road_closure.svg
+++ b/img/feedback/road_closure.svg
@@ -1,18 +1,84 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="70px" height="70px" viewBox="0 0 70 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
-    <title>feedback_button_5</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Feedback-UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Tintable-Assets" transform="translate(-277.000000, -526.000000)">
-            <g id="Group-Copy" transform="translate(13.000000, 238.000000)">
-                <g id="Group-8" transform="translate(0.000000, 120.000000)">
-                    <g id="feedback_button_5" transform="translate(264.000000, 168.000000)">
-                        <path d="M70,35 C70,54.3305 54.327,70 35,70 C15.673,70 0,54.3305 0,35 C0,15.6695 15.673,0 35,0 C54.327,0 70,15.6695 70,35 Z" id="Stroke-1-Copy-9" fill="#000000"></path>
-                        <path d="M35,15 C23.95425,15 15,23.95425 15,35 C15,46.04575 23.95425,55 35,55 C46.04575,55 55,46.04575 55,35 C55,23.95425 46.04575,15 35,15 Z M26.2304736,32 C25.550883,32 25,32.4197188 25,32.9375 L25,37.0625 C25,37.5802812 25.550883,38 26.2304736,38 L44.7695264,38 C45.449117,38 46,37.5802812 46,37.0625 L46,32.9375 C46,32.4197188 45.449117,32 44.7695264,32 L26.2304736,32 Z" id="Shape" fill="#FFFFFF"></path>
-                    </g>
-                </g>
-            </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   sodipodi:docname="road_closure.svg"
+   id="svg915"
+   version="1.1"
+   viewBox="0 0 70 70"
+   height="70px"
+   width="70px">
+  <metadata
+     id="metadata921">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>feedback_button_5</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs919" />
+  <sodipodi:namedview
+     inkscape:current-layer="feedback_button_5"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="35"
+     inkscape:cx="35"
+     inkscape:zoom="3.8857143"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview917"
+     inkscape:window-height="480"
+     inkscape:window-width="786"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+  <title
+     id="title904">feedback_button_5</title>
+  <desc
+     id="desc906">Created with Sketch.</desc>
+  <g
+     fill-rule="evenodd"
+     fill="none"
+     stroke-width="1"
+     stroke="none"
+     id="Feedback-UI">
+    <g
+       transform="translate(-277.000000, -526.000000)"
+       id="Tintable-Assets">
+      <g
+         transform="translate(13.000000, 238.000000)"
+         id="Group-Copy">
+        <g
+           transform="translate(0.000000, 120.000000)"
+           id="Group-8">
+          <g
+             transform="translate(264.000000, 168.000000)"
+             id="feedback_button_5">
+            <path
+               style="fill:#000000"
+               d="M 35,15 C 23.95425,15 15,23.95425 15,35 15,46.04575 23.95425,55 35,55 46.04575,55 55,46.04575 55,35 55,23.95425 46.04575,15 35,15 Z M 26.230474,32 C 25.550883,32 25,32.419719 25,32.9375 v 4.125 C 25,37.580281 25.550883,38 26.230474,38 H 44.769526 C 45.449117,38 46,37.580281 46,37.0625 v -4.125 C 46,32.419719 45.449117,32 44.769526,32 Z M 70,35 C 70,54.3305 54.327,70 35,70 15.673,70 0,54.3305 0,35 0,15.6695 15.673,0 35,0 54.327,0 70,15.6695 70,35 Z"
+               id="Shape" />
+          </g>
         </g>
+      </g>
     </g>
+  </g>
 </svg>

--- a/img/feedback/route_quality.svg
+++ b/img/feedback/route_quality.svg
@@ -1,55 +1,147 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="70px" height="70px" viewBox="0 0 70 70" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
-    <title>feedback_button_3</title>
-    <desc>Created with Sketch.</desc>
-    <defs>
-        <polygon id="path-1" points="0.04895 0.363089049 6.7327 0.363089049 6.7327 11 0.04895 11"></polygon>
-        <polygon id="path-3" points="0 -0.0001 28.2739 -0.0001 28.2739 30.8989 0 30.8989"></polygon>
-        <polygon id="path-5" points="0.6383 0.986 7.32205 0.986 7.32205 11.6217552 0.6383 11.6217552"></polygon>
-        <polygon id="path-7" points="0.9014 0.434 21.371 0.434 21.371 6.986 0.9014 6.986"></polygon>
-    </defs>
-    <g id="Feedback-UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Tintable-Assets" transform="translate(-30.000000, -526.000000)">
-            <g id="Group-Copy" transform="translate(13.000000, 238.000000)">
-                <g id="Group-8" transform="translate(0.000000, 120.000000)">
-                    <g id="feedback_button_3" transform="translate(17.000000, 168.000000)">
-                        <path d="M70,35 C70,54.3305 54.327,70 35,70 C15.673,70 0,54.3305 0,35 C0,15.6695 15.673,0 35,0 C54.327,0 70,15.6695 70,35 Z" id="Stroke-1-Copy-10" fill="#000000"></path>
-                        <g id="Icon" transform="translate(15.000000, 18.000000)">
-                            <g id="Group-3" transform="translate(0.000000, 23.014400)">
-                                <mask id="mask-2" fill="white">
-                                    <use xlink:href="#path-1"></use>
-                                </mask>
-                                <g id="Clip-2"></g>
-                                <path d="M0.4877,4.8181 C-0.0973,5.2931 -0.0973,6.0701 0.4877,6.5461 L5.6687,10.7521 C6.2537,11.2271 6.7327,10.9991 6.7327,10.2451 L6.7327,1.1181 C6.7327,0.3641 6.2537,0.1361 5.6687,0.6111 L0.4877,4.8181 Z" id="Fill-1" fill="#FFFFFF" mask="url(#mask-2)"></path>
-                            </g>
-                            <g id="Group-6" transform="translate(0.000000, 1.014400)">
-                                <mask id="mask-4" fill="white">
-                                    <use xlink:href="#path-3"></use>
-                                </mask>
-                                <g id="Clip-5"></g>
-                                <path d="M28.2739,15.4489 C28.2739,6.9169 21.3569,-0.0001 12.8249,-0.0001 L-0.0001,-0.0001 L-0.0001,6.4549 L12.8469,6.4549 C17.8199,6.4549 21.8519,10.4869 21.8519,15.4599 C21.8519,20.4329 17.8199,24.4649 12.8469,24.4649 L4.1309,24.4649 L4.1309,30.8989 L12.8249,30.8989 C21.3569,30.8989 28.2739,23.9819 28.2739,15.4489" id="Fill-4" fill="#FFFFFF" mask="url(#mask-4)"></path>
-                            </g>
-                            <g id="Group-9" transform="translate(32.000000, 0.014400)">
-                                <mask id="mask-6" fill="white">
-                                    <use xlink:href="#path-5"></use>
-                                </mask>
-                                <g id="Clip-8"></g>
-                                <path d="M6.8833,7.1677 C7.4683,6.6927 7.4683,5.9157 6.8833,5.4397 L1.7023,1.2337 C1.1173,0.7587 0.6383,0.9867 0.6383,1.7407 L0.6383,10.8677 C0.6383,11.6207 1.1173,11.8487 1.7023,11.3737 L6.8833,7.1677 Z" id="Fill-7" fill="#FFFFFF" mask="url(#mask-6)"></path>
-                            </g>
-                            <path d="M18.1914,21.9477 C17.7604,20.8957 17.5194,19.7467 17.5194,18.5397 C17.5194,16.3687 18.2884,14.3767 19.5684,12.8217 C18.5274,10.8767 16.6794,9.4307 14.4754,8.9237 C12.3654,11.5647 11.0964,14.9077 11.0964,18.5507 C11.0964,20.5467 11.4884,22.4477 12.1774,24.1987 L12.7414,24.1987 C14.8654,24.1987 16.7914,23.3377 18.1914,21.9477" id="Fill-10" fill="#FFFFFF"></path>
-                            <path d="M27.9194,9.5351 L35.2394,9.5351 L35.2394,3.1011 L26.5464,3.1011 C25.4064,3.1011 24.2984,3.2331 23.2284,3.4681 C25.2284,5.0901 26.8374,7.1661 27.9194,9.5351" id="Fill-12" fill="#FFFFFF"></path>
-                            <g id="Group-16" transform="translate(18.000000, 27.014400)">
-                                <mask id="mask-8" fill="white">
-                                    <use xlink:href="#path-7"></use>
-                                </mask>
-                                <g id="Clip-15"></g>
-                                <path d="M8.5244,0.531 C8.0994,0.531 7.6834,0.491 7.2744,0.434 C5.5464,2.403 3.3714,3.963 0.9014,4.951 C3.1574,6.239 5.7624,6.986 8.5464,6.986 L21.3714,6.986 L21.3714,0.531 L8.5244,0.531 Z" id="Fill-14" fill="#FFFFFF" mask="url(#mask-8)"></path>
-                            </g>
-                        </g>
-                    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   sodipodi:docname="route_quality.svg"
+   id="svg1155"
+   version="1.1"
+   viewBox="0 0 70 70"
+   height="70px"
+   width="70px">
+  <metadata
+     id="metadata1159">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>feedback_button_3</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:current-layer="g1194"
+     inkscape:window-maximized="1"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="32.555147"
+     inkscape:cx="30.110294"
+     inkscape:zoom="3.8857143"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     id="namedview1157"
+     inkscape:window-height="755"
+     inkscape:window-width="1280"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+  <title
+     id="title1112">feedback_button_3</title>
+  <desc
+     id="desc1114">Created with Sketch.</desc>
+  <defs
+     id="defs1120">
+    <polygon
+       points="0.04895 0.363089049 6.7327 0.363089049 6.7327 11 0.04895 11"
+       id="path-1" />
+    <polygon
+       points="0 -0.0001 28.2739 -0.0001 28.2739 30.8989 0 30.8989"
+       id="path-3" />
+    <polygon
+       points="0.6383 0.986 7.32205 0.986 7.32205 11.6217552 0.6383 11.6217552"
+       id="path-5" />
+    <polygon
+       points="0.9014 0.434 21.371 0.434 21.371 6.986 0.9014 6.986"
+       id="path-7" />
+  </defs>
+  <g
+     fill-rule="evenodd"
+     fill="none"
+     stroke-width="1"
+     stroke="none"
+     id="Feedback-UI">
+    <g
+       transform="translate(-30,-526)"
+       id="Tintable-Assets">
+      <g
+         transform="translate(13,238)"
+         id="Group-Copy">
+        <g
+           transform="translate(0,120)"
+           id="Group-8">
+          <g
+             transform="translate(17,168)"
+             id="feedback_button_3">
+            <g
+               transform="translate(15,18)"
+               id="Icon">
+              <g
+                 transform="translate(0,23.0144)"
+                 id="Group-3" />
+              <g
+                 transform="translate(0,1.0144)"
+                 id="Group-6">
+                <mask
+                   fill="#ffffff"
+                   id="mask-4">
+                  <use
+                     height="100%"
+                     width="100%"
+                     y="0"
+                     x="0"
+                     id="use1129"
+                     xlink:href="#path-3" />
+                </mask>
+                <g
+                   id="Clip-5" />
+              </g>
+              <g
+                 transform="translate(32,0.0144)"
+                 id="Group-9" />
+              <g
+                 transform="translate(18,27.0144)"
+                 id="Group-16">
+                <mask
+                   fill="#ffffff"
+                   id="mask-8">
+                  <use
+                     height="100%"
+                     width="100%"
+                     y="0"
+                     x="0"
+                     id="use1143"
+                     xlink:href="#path-7" />
+                </mask>
+                <g
+                   id="Clip-15" />
+                <g
+                   id="g1194">
+                  <path
+                     d="m 48.109375,19 c -0.283154,0.0171 -0.470703,0.284609 -0.470703,0.755859 v 1.345703 h -6.091797 c -1.14,0 -2.248359,0.132188 -3.318359,0.367188 2,1.622 3.609406,3.697406 4.691406,6.066406 h 4.71875 v 1.347656 c 0,0.753001 0.479453,0.98086 1.064453,0.50586 l 5.179687,-4.207031 c 0.585001,-0.475 0.585001,-1.252516 0,-1.728516 L 48.703125,19.248047 C 48.48375,19.069922 48.279268,18.98974 48.109375,19 Z M 15,19.013672 v 6.455078 h 12.847656 c 4.973,0 9.003906,4.032859 9.003906,9.005859 0,4.973 -4.030906,9.003907 -9.003906,9.003907 h -6.115234 v -1.345704 c 0,-0.753999 -0.479453,-0.982812 -1.064453,-0.507812 l -5.179688,4.207031 c -0.585,0.475 -0.585,1.252516 0,1.728516 l 5.179688,4.205078 c 0.585,0.475 1.064453,0.248141 1.064453,-0.505859 v -1.345704 h 6.091797 c 8.532,0 15.449219,-6.918171 15.449219,-15.451171 0,-8.532 -6.917219,-15.449219 -15.449219,-15.449219 z m 14.474609,7.910156 c -2.11,2.641 -3.378906,5.983953 -3.378906,9.626953 0,1.996 0.393031,3.897438 1.082031,5.648438 h 0.564454 c 2.124,0 4.049218,-0.861953 5.449218,-2.251953 -0.431,-1.052 -0.671875,-2.201203 -0.671875,-3.408204 0,-2.170999 0.768828,-4.161796 2.048828,-5.716796 -1.041,-1.945 -2.88975,-3.391438 -5.09375,-3.898438 z m 10.798829,18.525391 c -1.728001,1.969 -3.901094,3.527625 -6.371094,4.515625 C 36.158344,51.252844 38.762875,52 41.546875,52 H 54.371094 V 45.544922 H 41.523438 c -0.425,0 -0.841,-0.0387 -1.25,-0.0957 z M 70,35 C 70,54.3305 54.327,70 35,70 15.673,70 0,54.3305 0,35 0,15.6695 15.673,0 35,0 54.327,0 70,15.6695 70,35 Z"
+                     transform="translate(-33,-45.0144)"
+                     style="fill:#000000"
+                     mask="url(#mask-2)"
+                     id="Fill-1" />
                 </g>
+              </g>
             </g>
+          </g>
         </g>
+      </g>
     </g>
+  </g>
 </svg>


### PR DESCRIPTION
Knocked the white glyphs out of the feedback category icons so that the circles have holes in them. Now that each icon contains only transparent and black pixels, they can be used as template images on Apple platforms.

/cc @nishant-karajgikar @avi-c @abhishek1508 @JunDai @noracalabrese